### PR TITLE
Refactor deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Florent Veilly"]
 [dependencies]
 colored = "2.0"
 rstest = "0.18"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/src/json_parser.rs
+++ b/src/json_parser.rs
@@ -607,7 +607,7 @@ impl<'de> Deserialize<'de> for RuntimeObject {
     {
         // Instantiate our Visitor and ask the Deserializer to drive
         // it over the input data, resulting in an instance of RuntimeObject.
-        deserializer.deserialize_map(RuntimeObjectVisitor::new())
+        deserializer.deserialize_any(RuntimeObjectVisitor::new())
     }
 }
 
@@ -794,12 +794,12 @@ mod tests {
             "readc",
             "rnd",
             "srnd",
-            "visit", 
-            "seq", 
-            "thread", 
-            "done", 
+            "visit",
+            "seq",
+            "thread",
+            "done",
             "end",
-            "listInt", 
+            "listInt",
             "range"
 ]"#;
         let control_commands: Vec<ControlCommand> = vec![

--- a/src/json_parser.rs
+++ b/src/json_parser.rs
@@ -1,615 +1,6 @@
-use std::{error::Error, fmt, io::Read, rc::Rc};
+use std::fmt;
 
-use serde::de::{Deserialize, Deserializer, Error as SerdeError, MapAccess, SeqAccess, Visitor};
-use serde_json;
-
-use crate::{
-    error::InkError,
-    path::Path,
-    runtime::{
-        choice_point::ChoicePoint,
-        container::Container,
-        control_command::ControlCommand,
-        divert::{Divert, TargetType},
-        glue::Glue,
-        tag::Tag,
-        value::Value,
-        variable::{ReadCount, VariableAssignment, VariableReference},
-        RuntimeObject,
-    },
-    runtime_graph::RuntimeGraph,
-};
-
-struct RuntimeGraphVisitor {}
-
-impl RuntimeGraphVisitor {
-    fn new() -> Self {
-        RuntimeGraphVisitor {}
-    }
-}
-
-impl<'de> Visitor<'de> for RuntimeGraphVisitor {
-    // Our Visitor is going to produce a RuntimeGraph.
-    type Value = RuntimeGraph;
-
-    // Format a message stating what data this Visitor expects to receive.
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Runtime graph")
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let ink_version = match map.next_entry()? as Option<(&str, u32)> {
-            Some(("inkVersion", value)) => Some(value),
-            _ => None,
-        }
-        .ok_or(SerdeError::custom(
-            "Invalid runtime graph format, expected inkVersion",
-        ))?;
-
-        let container = match map.next_entry()? as Option<(&str, RuntimeObject)> {
-            Some(("root", value)) => match value {
-                RuntimeObject::Container(container) => Some(container),
-                _ => None,
-            },
-            _ => None,
-        }
-        .ok_or(SerdeError::custom(
-            "Invalid runtime graph format, expected root",
-        ))?;
-
-        let _list_defs = match map.next_entry()? as Option<(&str, ListDefinitions)> {
-            Some(("listDefs", value)) => Some(value),
-            _ => None,
-        }
-        .ok_or(SerdeError::custom(
-            "Invalid runtime graph format, expected listDefs",
-        ))?;
-
-        Ok(RuntimeGraph::new(ink_version, container))
-    }
-}
-
-impl<'de> Deserialize<'de> for RuntimeGraph {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Instantiate our Visitor and ask the Deserializer to drive
-        // it over the input data, resulting in an instance of RuntimeGraph.
-        deserializer.deserialize_map(RuntimeGraphVisitor::new())
-    }
-}
-
-struct RuntimeObjectVisitor {}
-
-impl RuntimeObjectVisitor {
-    fn new() -> Self {
-        RuntimeObjectVisitor {}
-    }
-}
-
-impl<'de> Visitor<'de> for RuntimeObjectVisitor {
-    // Our Visitor is going to produce a RuntimeObject.
-    type Value = RuntimeObject;
-
-    // Format a message stating what data this Visitor expects to receive.
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("Runtime object")
-    }
-
-    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v)))
-    }
-
-    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Int(v as i32)))
-    }
-
-    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Float(v)))
-    }
-
-    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Value(Value::Float(v as f32)))
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: SerdeError,
-    {
-        if v.starts_with("^") {
-            return Ok(RuntimeObject::Value(Value::String(
-                v.chars().skip(1).collect(),
-            )));
-        }
-
-        match v {
-            "\n" => Ok(RuntimeObject::Value(Value::String("\n".to_string()))),
-
-            // Glue
-            "<>" => Ok(RuntimeObject::Glue(Glue::Bidirectional)),
-            "G<" => Ok(RuntimeObject::Glue(Glue::Left)),
-            "G>" => Ok(RuntimeObject::Glue(Glue::Right)),
-
-            // Control Commands
-            "ev" => Ok(RuntimeObject::ControlCommand(ControlCommand::EvalStart)),
-            "out" => Ok(RuntimeObject::ControlCommand(ControlCommand::EvalOutput)),
-            "/ev" => Ok(RuntimeObject::ControlCommand(ControlCommand::EvalEnd)),
-            "du" => Ok(RuntimeObject::ControlCommand(ControlCommand::Duplicate)),
-            "pop" => Ok(RuntimeObject::ControlCommand(
-                ControlCommand::PopEvaluatedValue,
-            )),
-            "~ret" => Ok(RuntimeObject::ControlCommand(ControlCommand::PopFunction)),
-            "->->" => Ok(RuntimeObject::ControlCommand(ControlCommand::PopTunnel)),
-            "str" => Ok(RuntimeObject::ControlCommand(ControlCommand::BeginString)),
-            "/str" => Ok(RuntimeObject::ControlCommand(ControlCommand::EndString)),
-            "nop" => Ok(RuntimeObject::ControlCommand(ControlCommand::NoOp)),
-            "choiceCnt" => Ok(RuntimeObject::ControlCommand(ControlCommand::ChoiceCount)),
-            "turns" => Ok(RuntimeObject::ControlCommand(ControlCommand::TurnsSince)),
-            "readc" => Ok(RuntimeObject::ControlCommand(ControlCommand::ReadCount)),
-            "rnd" => Ok(RuntimeObject::ControlCommand(ControlCommand::Random)),
-            "srnd" => Ok(RuntimeObject::ControlCommand(ControlCommand::SeedRandom)),
-            "visit" => Ok(RuntimeObject::ControlCommand(ControlCommand::VisitIndex)),
-            "seq" => Ok(RuntimeObject::ControlCommand(
-                ControlCommand::SequenceShuffleIndex,
-            )),
-            "thread" => Ok(RuntimeObject::ControlCommand(ControlCommand::StartThread)),
-            "done" => Ok(RuntimeObject::ControlCommand(ControlCommand::Done)),
-            "end" => Ok(RuntimeObject::ControlCommand(ControlCommand::End)),
-            "listInt" => Ok(RuntimeObject::ControlCommand(ControlCommand::ListFromInt)),
-            "range" => Ok(RuntimeObject::ControlCommand(ControlCommand::ListRange)),
-
-            // Native functions
-            //Some("L^") => {},
-
-            // Void
-            "void" => Ok(RuntimeObject::Void),
-
-            _ => Err(SerdeError::custom("Invalid String")),
-        }
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let mut opt_key: Option<&str> = map.next_key()?;
-        if let &Some(key) = &opt_key {
-            match key {
-                // Divert target value to path
-                "^->" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => match Path::from_str(target) {
-                            Some(path) => {
-                                return Ok(RuntimeObject::Value(Value::DivertTarget(path)))
-                            }
-                            _ => return Err(SerdeError::custom("Cannot parse target path")),
-                        },
-                        _ => return Err(SerdeError::custom("Unexpected divert target value type")),
-                    }
-                }
-
-                // VariablePointerValue
-                "^var" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(name) => {
-                            let mut context_index = -1;
-                            if let Some(("ci", value)) = map.next_entry()? as Option<(&str, i32)> {
-                                context_index = value;
-                            }
-                            return Ok(RuntimeObject::Value(Value::VariablePointer(
-                                name.to_owned(),
-                                context_index,
-                            )));
-                        }
-                        _ => {
-                            return Err(SerdeError::custom(
-                                "Unexpected variable pointer value type",
-                            ))
-                        }
-                    }
-                }
-
-                // Divert
-                "->" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => {
-                            let mut divert = Divert::new();
-
-                            let entry: Option<(&str, bool)> = map.next_entry()?;
-                            match entry {
-                                // Case {"->": "variableTarget", "var": true}
-                                Some(("var", true)) => {
-                                    divert.set_target(TargetType::Name(target.to_owned()));
-
-                                    // Case {"->": "variableTarget", "var": true, "c": true}
-                                    if let Some(("c", true)) = map.next_entry()? {
-                                        divert.set_is_conditional(true);
-                                    }
-                                }
-                                _ => {
-                                    match Path::from_str(target) {
-                                        Some(path) => divert.set_target(TargetType::Path(path)),
-                                        _ => {
-                                            return Err(SerdeError::custom(
-                                                "Cannot parse divert target path",
-                                            ))
-                                        }
-                                    }
-
-                                    // Case {"->": "variableTarget", "c": true}
-                                    if let Some(("c", true)) = entry {
-                                        divert.set_is_conditional(true);
-                                    }
-                                }
-                            }
-                            return Ok(RuntimeObject::Divert(divert));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected divert type")),
-                    }
-                }
-
-                // Function Call
-                "f()" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => {
-                            let mut divert = Divert::new_function();
-
-                            match Path::from_str(target) {
-                                Some(path) => divert.set_target(TargetType::Path(path)),
-                                _ => return Err(SerdeError::custom("Cannot parse target path")),
-                            }
-
-                            // Case {"f()": "path.to.func", "c": true}
-                            if let Some(("c", true)) = map.next_entry()? {
-                                divert.set_is_conditional(true);
-                            }
-
-                            return Ok(RuntimeObject::Divert(divert));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected function call type")),
-                    }
-                }
-
-                // Tunnel
-                "->t->" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => {
-                            let mut divert = Divert::new_tunnel();
-
-                            match Path::from_str(target) {
-                                Some(path) => divert.set_target(TargetType::Path(path)),
-                                _ => return Err(SerdeError::custom("Cannot parse target path")),
-                            }
-
-                            // Case {"->t->": "path.tunnel", "c": true}
-                            if let Some(("c", true)) = map.next_entry()? {
-                                divert.set_is_conditional(true);
-                            }
-
-                            return Ok(RuntimeObject::Divert(divert));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected tunnel type")),
-                    }
-                }
-
-                // External function
-                "x()" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => {
-                            let mut divert = Divert::new_external_function();
-
-                            match Path::from_str(target) {
-                                Some(path) => divert.set_target(TargetType::Path(path)),
-                                _ => return Err(SerdeError::custom("Cannot parse target path")),
-                            }
-
-                            // Case {"x()": "externalFuncName", "exArgs": 5}
-                            if let Some(("exArgs", external_args)) = map.next_entry()? {
-                                divert.set_external_args(external_args);
-                            }
-
-                            // Case {"x()": "externalFuncName", "exArgs": 5, "c": true}
-                            if let Some(("c", true)) = map.next_entry()? {
-                                divert.set_is_conditional(true);
-                            }
-
-                            return Ok(RuntimeObject::Divert(divert));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected external function type")),
-                    }
-                }
-
-                // Choice
-                "*" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => {
-                            let mut choice = ChoicePoint::new();
-
-                            match Path::from_str(target) {
-                                Some(path) => choice.set_path_on_choice(path),
-                                _ => return Err(SerdeError::custom("Cannot parse choice path")),
-                            }
-
-                            if let Some(("flg", flags)) = map.next_entry()? {
-                                choice.set_flags(flags);
-                            }
-
-                            return Ok(RuntimeObject::Choice(choice));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected choice type")),
-                    }
-                }
-
-                // Variable reference
-                "VAR?" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(name) => {
-                            return Ok(RuntimeObject::VariableReference(VariableReference::new(
-                                name.to_owned(),
-                            )))
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected variable reference type")),
-                    }
-                }
-
-                // Read Count
-                "CNT?" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(target) => match Path::from_str(target) {
-                            Some(path) => {
-                                return Ok(RuntimeObject::ReadCount(ReadCount::new(path)))
-                            }
-                            _ => return Err(SerdeError::custom("Cannot parse read count target")),
-                        },
-                        _ => return Err(SerdeError::custom("Unexpected read count type")),
-                    }
-                }
-
-                // Variable assignment
-                "VAR=" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(name) => {
-                            if let Some(("re", re)) = map.next_entry()? as Option<(&str, bool)> {
-                                return Ok(RuntimeObject::VariableAssignment(
-                                    VariableAssignment::new(name.to_owned(), !re, true),
-                                ));
-                            }
-
-                            return Ok(RuntimeObject::VariableAssignment(VariableAssignment::new(
-                                name.to_owned(),
-                                true,
-                                true,
-                            )));
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected variable assignment type")),
-                    }
-                }
-
-                // Temporary variable
-                "temp=" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(name) => {
-                            return Ok(RuntimeObject::VariableAssignment(VariableAssignment::new(
-                                name.to_owned(),
-                                true,
-                                false,
-                            )))
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected temporary variable type")),
-                    }
-                }
-
-                // Tag
-                "#" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(tag) => return Ok(RuntimeObject::Tag(Tag::new(tag.to_owned()))),
-                        _ => return Err(SerdeError::custom("Unexpected temp var name type")),
-                    }
-                }
-
-                // List
-                "list" => return Err(SerdeError::custom("TODO")),
-
-                _ => {}
-            }
-        }
-
-        let mut opt_container: Option<Container> = None;
-
-        while let Some(key) = opt_key {
-            match key {
-                // Container name
-                "#n" => {
-                    let value: Option<&str> = map.next_value()?;
-                    match value {
-                        Some(name) => {
-                            if opt_container.is_none() {
-                                opt_container = Some(Container::new());
-                            }
-
-                            if let Some(ref mut container_ref) = opt_container.as_mut() {
-                                container_ref.set_name(name.to_owned());
-                            }
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected container name type")),
-                    }
-                }
-
-                // Container flags
-                "#f" => {
-                    let value: Option<u8> = map.next_value()?;
-                    match value {
-                        Some(flags) => {
-                            if opt_container.is_none() {
-                                opt_container = Some(Container::new());
-                            }
-
-                            if let Some(ref mut container_ref) = opt_container.as_mut() {
-                                container_ref.set_count_flags(flags);
-                            }
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected container flags type")),
-                    }
-                }
-
-                // Sub-container
-                _ => {
-                    let value: Option<RuntimeObject> = map.next_value()?;
-                    match value {
-                        Some(obj) => {
-                            if let RuntimeObject::Container(mut sub_container_rc) = obj {
-                                if opt_container.is_none() {
-                                    opt_container = Some(Container::new());
-                                }
-
-                                match Rc::get_mut(&mut sub_container_rc) {
-                                    Some(sub_container) => sub_container.set_name(key.to_owned()),
-                                    _ => {
-                                        return Err(SerdeError::custom(
-                                            "Fail to get mutable sub-container",
-                                        ))
-                                    }
-                                }
-
-                                if let Some(ref mut container_ref) = opt_container.as_mut() {
-                                    container_ref
-                                        .add_child(RuntimeObject::Container(sub_container_rc));
-                                }
-                            }
-                        }
-                        _ => return Err(SerdeError::custom("Unexpected sub-container type")),
-                    }
-                }
-            }
-
-            opt_key = map.next_key()?;
-        }
-
-        if let Some(container) = opt_container {
-            return Ok(RuntimeObject::Container(Rc::new(container)));
-        }
-
-        Err(SerdeError::custom(
-            "Runtime Object dictionary match not found",
-        ))
-    }
-
-    fn visit_seq<V>(self, mut seq: V) -> Result<Self::Value, V::Error>
-    where
-        V: SeqAccess<'de>,
-    {
-        let mut runtime_objects: Vec<RuntimeObject> = Vec::new();
-
-        let mut opt_child: Option<RuntimeObject> = seq.next_element()?;
-        while let Some(child) = opt_child {
-            opt_child = seq.next_element()?;
-
-            if opt_child.is_some() {
-                runtime_objects.push(child);
-            } else {
-                if let RuntimeObject::Container(mut container_rc) = child {
-                    match Rc::get_mut(&mut container_rc) {
-                        Some(container) => container.prepend(runtime_objects),
-                        _ => return Err(SerdeError::custom("Fail to get mutable container")),
-                    }
-
-                    return Ok(RuntimeObject::Container(container_rc));
-                }
-            }
-        }
-
-        Ok(RuntimeObject::Container(Rc::new(
-            Container::from_runtime_object_vec(runtime_objects),
-        )))
-    }
-
-    fn visit_unit<E>(self) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(RuntimeObject::Null)
-    }
-}
-
-impl<'de> Deserialize<'de> for RuntimeObject {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // Instantiate our Visitor and ask the Deserializer to drive
-        // it over the input data, resulting in an instance of RuntimeObject.
-        deserializer.deserialize_any(RuntimeObjectVisitor::new())
-    }
-}
+use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
 
 // TODO
 struct ListDefinitions {}
@@ -650,30 +41,20 @@ impl<'de> Deserialize<'de> for ListDefinitions {
     }
 }
 
-pub struct RuntimeGraphBuilder {}
-
-impl RuntimeGraphBuilder {
-    pub fn from_str(s: &str) -> Result<RuntimeGraph, InkError> {
-        serde_json::from_str(s).map_err(|e| InkError::from(e))
-    }
-
-    pub fn from_slice(v: &[u8]) -> Result<RuntimeGraph, InkError> {
-        serde_json::from_slice(v).map_err(|e| InkError::from(e))
-    }
-
-    pub fn from_reader<R>(rdr: R) -> Result<RuntimeGraph, InkError>
-    where
-        R: Read,
-    {
-        serde_json::from_reader(rdr).map_err(|e| InkError::from(e))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::runtime::divert::PushPopType;
-
-    use super::*;
+    use crate::{
+        runtime::{
+            container::Container,
+            control_command::ControlCommand,
+            divert::{PushPopType, TargetType},
+            glue::Glue,
+            native_function_call::NativeFunctionCall,
+            value::Value,
+            RuntimeObject,
+        },
+        runtime_graph::RuntimeGraph,
+    };
 
     #[test]
     fn value_int_test() {
@@ -721,8 +102,10 @@ mod tests {
         let json = "{\"^->\":\"0.g-0.2.$r1\"}";
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
-            RuntimeObject::Value(ref value) => match value {
-                &Value::DivertTarget(ref path) => assert_eq!(path.to_string(), "0.g-0.2.$r1"),
+            RuntimeObject::Value(value) => match value {
+                Value::DivertTarget { target_path } => {
+                    assert_eq!(target_path.to_string(), "0.g-0.2.$r1")
+                }
                 _ => assert!(false),
             },
             _ => assert!(false),
@@ -735,7 +118,10 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Value(value) => match value {
-                Value::VariablePointer(name, context_index) => {
+                Value::VariablePointer {
+                    name,
+                    context_index,
+                } => {
                     assert_eq!(name, "varname");
                     assert_eq!(context_index, 0);
                 }
@@ -747,11 +133,11 @@ mod tests {
 
     #[test]
     fn newline_test() {
-        let json = "[\"\\n\"]";
+        let json = r##"["\n"]"##;
         let runtime_objects: Vec<RuntimeObject> = serde_json::from_str(json).unwrap();
         match runtime_objects.get(0).unwrap() {
-            &RuntimeObject::Value(ref value) => match value {
-                &Value::String(ref string_value) => assert_eq!(string_value, "\n"),
+            RuntimeObject::Value(value) => match value {
+                Value::String(string_value) => assert_eq!(string_value, "\n"),
                 _ => assert!(false),
             },
             _ => assert!(false),
@@ -771,6 +157,59 @@ mod tests {
 
             match runtime_object {
                 &RuntimeObject::Glue(ref value) => assert_eq!(value, glue),
+                _ => assert!(false),
+            }
+        }
+    }
+
+    #[test]
+    fn native_functions_test() {
+        let json = r#"[
+            "+",
+            "-",
+            "/",
+            "*",
+            "%",
+            "_",
+            "==",
+            ">",
+            "<",
+            ">=",
+            "<=",
+            "!=",
+            "!",
+            "&&",
+            "||",
+            "MIN",
+            "MAX"
+]"#;
+        let native_commands = vec![
+            NativeFunctionCall::Plus,
+            NativeFunctionCall::Minus,
+            NativeFunctionCall::Divide,
+            NativeFunctionCall::Multiply,
+            NativeFunctionCall::Modulo,
+            NativeFunctionCall::UnaryMinus,
+            NativeFunctionCall::Eq,
+            NativeFunctionCall::GT,
+            NativeFunctionCall::LT,
+            NativeFunctionCall::GEq,
+            NativeFunctionCall::LEq,
+            NativeFunctionCall::NEq,
+            NativeFunctionCall::UnaryNot,
+            NativeFunctionCall::And,
+            NativeFunctionCall::Or,
+            NativeFunctionCall::Min,
+            NativeFunctionCall::Max,
+        ];
+        let runtime_objects: Vec<RuntimeObject> = serde_json::from_str(json).unwrap();
+        assert_eq!(native_commands.len(), runtime_objects.len());
+
+        for (i, runtime_object) in runtime_objects.iter().enumerate() {
+            let control_command = native_commands.get(i).unwrap();
+
+            match runtime_object {
+                RuntimeObject::NativeFunctionCall(value) => assert_eq!(value, control_command),
                 _ => assert!(false),
             }
         }
@@ -834,7 +273,7 @@ mod tests {
             let control_command = control_commands.get(i).unwrap();
 
             match runtime_object {
-                &RuntimeObject::ControlCommand(ref value) => assert_eq!(value, control_command),
+                RuntimeObject::ControlCommand(value) => assert_eq!(value, control_command),
                 _ => assert!(false),
             }
         }
@@ -844,8 +283,7 @@ mod tests {
     fn void_test() {
         let json = "[\"void\"]";
         let runtime_objects: Vec<RuntimeObject> = serde_json::from_str(json).unwrap();
-        // TODO: impl PartialEq for RuntimeObject
-        //assert_eq!(runtime_objects.get(0).unwrap(), RuntimeObject::Void);
+        assert_eq!(*runtime_objects.get(0).unwrap(), RuntimeObject::Void);
     }
 
     #[test]
@@ -854,16 +292,16 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                match divert.target().unwrap() {
-                    &TargetType::Path(ref path) => {
+                match divert.target.unwrap() {
+                    TargetType::Path(path) => {
                         assert_eq!(path.to_string(), ".^.s");
                     }
                     _ => assert!(false),
                 }
 
-                assert_eq!(divert.stack_push_type(), &PushPopType::None);
-                assert_eq!(divert.pushes_to_stack(), false);
-                assert_eq!(divert.is_conditional(), false);
+                assert_eq!(divert.stack_push_type, PushPopType::None);
+                assert_eq!(divert.pushes_to_stack, false);
+                assert_eq!(divert.is_conditional, false);
             }
             _ => assert!(false),
         }
@@ -875,7 +313,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                assert_eq!(divert.is_conditional(), true);
+                assert_eq!(divert.is_conditional, true);
             }
             _ => assert!(false),
         }
@@ -887,16 +325,16 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                match divert.target().unwrap() {
-                    &TargetType::Name(ref target_name) => {
+                match divert.target.unwrap() {
+                    TargetType::VarName(target_name) => {
                         assert_eq!(target_name, "$r");
                     }
                     _ => assert!(false),
                 }
 
-                assert_eq!(divert.stack_push_type(), &PushPopType::None);
-                assert_eq!(divert.pushes_to_stack(), false);
-                assert_eq!(divert.is_conditional(), false);
+                assert_eq!(divert.stack_push_type, PushPopType::None);
+                assert_eq!(divert.pushes_to_stack, false);
+                assert_eq!(divert.is_conditional, false);
             }
             _ => assert!(false),
         }
@@ -908,16 +346,16 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                match divert.target().unwrap() {
-                    &TargetType::Path(ref path) => {
+                match divert.target.unwrap() {
+                    TargetType::Path(ref path) => {
                         assert_eq!(path.to_string(), "0.g-0.2.c.12.0.c.11.g-0.2.c.$r2");
                     }
                     _ => assert!(false),
                 }
 
-                assert_eq!(divert.stack_push_type(), &PushPopType::Function);
-                assert_eq!(divert.pushes_to_stack(), true);
-                assert_eq!(divert.is_conditional(), false);
+                assert_eq!(divert.stack_push_type, PushPopType::Function);
+                assert_eq!(divert.pushes_to_stack, true);
+                assert_eq!(divert.is_conditional, false);
             }
             _ => assert!(false),
         }
@@ -929,7 +367,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                assert_eq!(divert.is_conditional(), true);
+                assert_eq!(divert.is_conditional, true);
             }
             _ => assert!(false),
         }
@@ -941,16 +379,16 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                match divert.target().unwrap() {
-                    &TargetType::Path(ref path) => {
+                match divert.target.unwrap() {
+                    TargetType::Path(ref path) => {
                         assert_eq!(path.to_string(), "0.g-0.2.c.12.0.c.11.g-0.2.$r1");
                     }
                     _ => assert!(false),
                 }
 
-                assert_eq!(divert.stack_push_type(), &PushPopType::Tunnel);
-                assert_eq!(divert.pushes_to_stack(), true);
-                assert_eq!(divert.is_conditional(), false);
+                assert_eq!(divert.stack_push_type, PushPopType::Tunnel);
+                assert_eq!(divert.pushes_to_stack, true);
+                assert_eq!(divert.is_conditional, false);
             }
             _ => assert!(false),
         }
@@ -962,7 +400,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                assert_eq!(divert.is_conditional(), true);
+                assert_eq!(divert.is_conditional, true);
             }
             _ => assert!(false),
         }
@@ -974,17 +412,17 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                match divert.target().unwrap() {
-                    &TargetType::Path(ref path) => {
-                        assert_eq!(path.to_string(), "0.g-0.3.$r1");
+                match divert.target.unwrap() {
+                    TargetType::ExternalName(string) => {
+                        assert_eq!(string, "0.g-0.3.$r1");
                     }
                     _ => assert!(false),
                 }
 
-                assert_eq!(divert.stack_push_type(), &PushPopType::Function);
-                assert_eq!(divert.pushes_to_stack(), false);
-                assert_eq!(divert.is_conditional(), false);
-                assert_eq!(divert.is_external(), true);
+                assert_eq!(divert.stack_push_type, PushPopType::Function);
+                assert_eq!(divert.pushes_to_stack, false);
+                assert_eq!(divert.is_conditional, false);
+                assert_eq!(divert.is_external, true);
             }
             _ => assert!(false),
         }
@@ -996,7 +434,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                assert_eq!(divert.external_args().unwrap(), 5);
+                assert_eq!(divert.external_args.unwrap(), 5);
             }
             _ => assert!(false),
         }
@@ -1008,7 +446,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Divert(divert) => {
-                assert_eq!(divert.is_conditional(), true);
+                assert_eq!(divert.is_conditional, true);
             }
             _ => assert!(false),
         }
@@ -1020,12 +458,12 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Choice(choice) => {
-                assert_eq!(choice.path_on_choice().unwrap().to_string(), ".^.c");
-                assert_eq!(choice.has_condition(), false);
-                assert_eq!(choice.has_start_content(), true);
-                assert_eq!(choice.has_choice_only_content(), false);
-                assert_eq!(choice.is_invisible_default(), false);
-                assert_eq!(choice.once_only(), true);
+                assert_eq!(choice.choice_target_path.unwrap().to_string(), ".^.c");
+                assert_eq!(choice.has_condition, false);
+                assert_eq!(choice.has_start_content, true);
+                assert_eq!(choice.has_choice_only_content, false);
+                assert_eq!(choice.is_invisible_default, false);
+                assert_eq!(choice.once_only, true);
             }
             _ => assert!(false),
         }
@@ -1037,7 +475,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::VariableReference(variable) => {
-                assert_eq!(variable.name(), "danger");
+                assert_eq!(variable.name, "danger");
             }
             _ => assert!(false),
         }
@@ -1049,7 +487,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::ReadCount(variable) => {
-                assert_eq!(variable.target().to_string(), "the_hall.light_switch");
+                assert_eq!(variable.target.to_string(), "the_hall.light_switch");
             }
             _ => assert!(false),
         }
@@ -1061,9 +499,9 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::VariableAssignment(variable) => {
-                assert_eq!(variable.name(), "money");
-                assert_eq!(variable.is_new_declaration(), true);
-                assert_eq!(variable.is_global(), true);
+                assert_eq!(variable.name, "money");
+                assert_eq!(variable.is_new_declaration, true);
+                assert_eq!(variable.is_global, true);
             }
             _ => assert!(false),
         }
@@ -1075,9 +513,9 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::VariableAssignment(variable) => {
-                assert_eq!(variable.name(), "money");
-                assert_eq!(variable.is_new_declaration(), false);
-                assert_eq!(variable.is_global(), true);
+                assert_eq!(variable.name, "money");
+                assert_eq!(variable.is_new_declaration, false);
+                assert_eq!(variable.is_global, true);
             }
             _ => assert!(false),
         }
@@ -1089,9 +527,9 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::VariableAssignment(variable) => {
-                assert_eq!(variable.name(), "x");
-                assert_eq!(variable.is_new_declaration(), true);
-                assert_eq!(variable.is_global(), false);
+                assert_eq!(variable.name, "x");
+                assert_eq!(variable.is_new_declaration, true);
+                assert_eq!(variable.is_global, false);
             }
             _ => assert!(false),
         }
@@ -1103,7 +541,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Tag(tag) => {
-                assert_eq!(tag.text(), "This is a tag");
+                assert_eq!(tag.text, "This is a tag");
             }
             _ => assert!(false),
         }
@@ -1115,6 +553,7 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Container(container) => {
+                let container = &container.content;
                 assert_eq!(container.len(), 2);
 
                 match container.get(0).unwrap() {
@@ -1127,16 +566,16 @@ mod tests {
 
                 match container.get(1).unwrap() {
                     &RuntimeObject::Divert(ref divert) => {
-                        match divert.target().unwrap() {
-                            &TargetType::Name(ref target_name) => {
+                        match divert.target.as_ref().unwrap() {
+                            TargetType::VarName(ref target_name) => {
                                 assert_eq!(target_name, "$r");
                             }
                             _ => assert!(false),
                         }
 
-                        assert_eq!(divert.stack_push_type(), &PushPopType::None);
-                        assert_eq!(divert.pushes_to_stack(), false);
-                        assert_eq!(divert.is_conditional(), false);
+                        assert_eq!(divert.stack_push_type, PushPopType::None);
+                        assert_eq!(divert.pushes_to_stack, false);
+                        assert_eq!(divert.is_conditional, false);
                     }
                     _ => assert!(false),
                 }
@@ -1151,10 +590,11 @@ mod tests {
         let runtime_object: RuntimeObject = serde_json::from_str(json).unwrap();
         match runtime_object {
             RuntimeObject::Container(container) => {
-                assert_eq!(container.len(), 2);
-                assert_eq!(container.name().unwrap(), "container");
+                let content = &container.content;
+                assert_eq!(content.len(), 1);
+                assert_eq!(container.name.as_ref().unwrap(), "container");
 
-                match container.get(0).unwrap() {
+                match content.get(0).unwrap() {
                     &RuntimeObject::Value(ref value) => match value {
                         &Value::String(ref str) => assert_eq!(str, "test"),
                         _ => assert!(false),
@@ -1162,27 +602,30 @@ mod tests {
                     _ => assert!(false),
                 }
 
-                match container.get(1).unwrap() {
-                    &RuntimeObject::Container(ref sub_container) => {
-                        assert_eq!(sub_container.len(), 2);
-                        assert_eq!(sub_container.name().unwrap(), "subContainer");
+                let sub_object = &container.named_subelements["subContainer"];
 
-                        match sub_container.get(0).unwrap() {
-                            &RuntimeObject::Value(ref value) => match value {
-                                &Value::Int(int_value) => assert_eq!(int_value, 5),
-                                _ => assert!(false),
-                            },
-                            _ => assert!(false),
-                        }
+                let RuntimeObject::Container(sub_container) = sub_object else {
+                    panic!()
+                };
 
-                        match sub_container.get(1).unwrap() {
-                            &RuntimeObject::Value(ref value) => match value {
-                                &Value::Int(int_value) => assert_eq!(int_value, 6),
-                                _ => assert!(false),
-                            },
-                            _ => assert!(false),
-                        }
-                    }
+                let sub_content = &sub_container.content;
+                assert_eq!(sub_content.len(), 2);
+                // this assert fails until naming of nested containers is supported
+                assert_eq!(sub_container.name.as_ref().unwrap(), "subContainer");
+
+                match sub_content.get(0).unwrap() {
+                    RuntimeObject::Value(value) => match value {
+                        Value::Int(int_value) => assert_eq!(*int_value, 5),
+                        _ => assert!(false),
+                    },
+                    _ => assert!(false),
+                }
+
+                match sub_content.get(1).unwrap() {
+                    &RuntimeObject::Value(ref value) => match value {
+                        &Value::Int(int_value) => assert_eq!(int_value, 6),
+                        _ => assert!(false),
+                    },
                     _ => assert!(false),
                 }
             }
@@ -1191,10 +634,31 @@ mod tests {
     }
 
     #[test]
-    fn runtime_grahp_test() {
+    fn runtime_graph_test() {
         let json = r###"{"inkVersion":17,"root":[[["^I looked at Monsieur Fogg","\n",["ev",{"^->":"0.g-0.2.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^... and I could contain myself no longer.",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"\n","\n","^'What is the purpose of our journey, Monsieur?'","\n","^'A wager,' he replied.","\n",[["ev",{"^->":"0.g-0.2.c.12.0.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^'A wager!'",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"^ I returned.","\n","\n","^He nodded.","\n",[["ev",{"^->":"0.g-0.2.c.12.0.c.11.0.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^'But surely that is foolishness!'",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.11.0.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"\n","\n",{"->":".^.^.^.g-0"},{"#f":5}]}],["ev",{"^->":"0.g-0.2.c.12.0.c.11.1.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^'A most serious matter then!'",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.11.1.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"\n","\n",{"->":".^.^.^.g-0"},{"#f":5}]}],{"g-0":["^He nodded again.","\n",["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.2.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^'But can we win?'",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.2.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"\n","\n","^'That is what we will endeavour to find out,' he answered.","\n",{"->":"0.g-0.2.c.12.g-0"},{"#f":5}]}],["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.3.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^'A modest wager, I trust?'",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.3.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"\n","\n","^'Twenty thousand pounds,' he replied, quite flatly.","\n",{"->":"0.g-0.2.c.12.g-0"},{"#f":5}]}],["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.4.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","str","^.","/str","/ev",{"*":".^.c","flg":22},{"s":["^I asked nothing further of him then",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.0.c.11.g-0.4.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"^, and after a final, polite cough, he offered nothing more to me. ","<>","\n","\n",{"->":"0.g-0.2.c.12.g-0"},{"#f":5}]}],null]}],{"#f":5}]}],["ev",{"^->":"0.g-0.2.c.12.1.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","str","^.'","/str","/ev",{"*":".^.c","flg":22},{"s":["^'Ah",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.2.c.12.1.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"^,' I replied, uncertain what I thought.","\n","\n",{"->":".^.^.^.g-0"},{"#f":5}]}],{"g-0":["^After that, ","<>","\n",{"->":"0.g-1"},null]}],{"#f":5}]}],["ev",{"^->":"0.g-0.3.$r1"},{"temp=":"$r"},"str",{"->":".^.s"},[{"#n":"$r1"}],"/str","/ev",{"*":".^.c","flg":18},{"s":["^... but I said nothing",{"->":"$r","var":true},null],"c":["ev",{"^->":"0.g-0.3.c.$r2"},"/ev",{"temp=":"$r"},{"->":".^.^.s"},[{"#n":"$r2"}],"^ and ","<>","\n","\n",{"->":"0.g-1"},{"#f":5}]}],{"#n":"g-0"}],{"g-1":["^we passed the day in silence.","\n",["end",{"#n":"g-2"}],null]}],"done",{"#f":3}],"listDefs":{}}"###;
-        let runtime_graph: RuntimeGraph = RuntimeGraphBuilder::from_str(json).unwrap();
-        assert_eq!(runtime_graph.ink_version(), 17)
+        let runtime_graph: RuntimeGraph = serde_json::from_str(json).unwrap();
+        assert_eq!(runtime_graph.ink_version, 17)
+    }
+
+    #[test]
+    fn mini_runtime_graph_test() {
+        let json = r###"{"inkVersion":21,"root":[["end",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}],"listDefs":{}}"###;
+        let runtime_graph: RuntimeGraph = serde_json::from_str(json).unwrap();
+        assert_eq!(runtime_graph.ink_version, 21)
+    }
+
+    #[test]
+    fn container_length_test() {
+        let json = r###"[["end",["done",{"#f":5,"#n":"g-0"}],null],"done",{"#f":1}]"###;
+        let container: Container = serde_json::from_str(json).unwrap();
+        assert_eq!(container.content.len(), 2);
+    }
+
+    #[test]
+    fn null_container_test() {
+        let json = r###"[null]"###;
+        let container: Container = serde_json::from_str(json).unwrap();
+        assert_eq!(container.content.len(), 0);
     }
 
     // FIXME: For now serde MapAccess::next_value() for &str fail when deserializing from a reader

--- a/src/runtime/choice_point.rs
+++ b/src/runtime/choice_point.rs
@@ -4,25 +4,26 @@ use serde::Deserialize;
 
 use crate::path::Path;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default, PartialEq, Eq, Clone)]
+#[serde(from = "ChoicePointData")]
 pub struct ChoicePoint {
-    has_condition: bool,
-    has_start_content: bool,
-    has_choice_only_content: bool,
-    is_invisible_default: bool,
-    once_only: bool,
-    path_on_choice: Option<Path>,
+    pub has_condition: bool,
+    pub has_start_content: bool,
+    pub has_choice_only_content: bool,
+    pub is_invisible_default: bool,
+    pub once_only: bool,
+    pub choice_target_path: Option<Path>,
 }
 
 impl ChoicePoint {
-    pub fn new() -> ChoicePoint {
+    pub fn new(choice_target_path: Option<Path>, flags: u8) -> ChoicePoint {
         ChoicePoint {
-            has_condition: false,
-            has_start_content: false,
-            has_choice_only_content: false,
-            is_invisible_default: false,
-            once_only: false,
-            path_on_choice: None,
+            has_condition: flags & 0x1 > 0,
+            has_start_content: flags & 0x2 > 0,
+            has_choice_only_content: flags & 0x4 > 0,
+            is_invisible_default: flags & 0x8 > 0,
+            once_only: flags & 0x10 > 0,
+            choice_target_path,
         }
     }
 
@@ -51,53 +52,30 @@ impl ChoicePoint {
 
         flags
     }
-
-    pub fn set_flags(&mut self, flags: u8) {
-        self.has_condition = flags & 0x1 > 0;
-        self.has_start_content = flags & 0x2 > 0;
-        self.has_choice_only_content = flags & 0x4 > 0;
-        self.is_invisible_default = flags & 0x8 > 0;
-        self.once_only = flags & 0x10 > 0;
-    }
-
-    pub fn has_condition(&self) -> bool {
-        self.has_condition
-    }
-
-    pub fn has_start_content(&self) -> bool {
-        self.has_start_content
-    }
-
-    pub fn has_choice_only_content(&self) -> bool {
-        self.has_choice_only_content
-    }
-
-    pub fn is_invisible_default(&self) -> bool {
-        self.is_invisible_default
-    }
-
-    pub fn once_only(&self) -> bool {
-        self.once_only
-    }
-
-    pub fn path_on_choice(&self) -> Option<&Path> {
-        match self.path_on_choice {
-            Some(ref path) => {
-                // TODO
-                Some(path)
-            }
-            _ => None,
-        }
-    }
-
-    pub fn set_path_on_choice(&mut self, path: Path) {
-        self.path_on_choice = Some(path);
-    }
 }
 
 impl fmt::Display for ChoicePoint {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // TODO
         write!(f, "")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChoicePointData {
+    #[serde(rename = "*")]
+    choice_target_path: Path,
+    #[serde(rename = "flg")]
+    flags: u8,
+}
+
+impl From<ChoicePointData> for ChoicePoint {
+    fn from(
+        ChoicePointData {
+            choice_target_path,
+            flags,
+        }: ChoicePointData,
+    ) -> Self {
+        ChoicePoint::new(Some(choice_target_path), flags)
     }
 }

--- a/src/runtime/container.rs
+++ b/src/runtime/container.rs
@@ -118,12 +118,11 @@ impl TryFrom<Vec<ContainerElement>> for Container {
     type Error = ContainerError;
 
     fn try_from(mut elements: Vec<ContainerElement>) -> Result<Container, ContainerError> {
-        use ContainerElement as CE;
         // take last element of Container
         let data = match elements.pop() {
-            Some(CE::SpecialFinal(Some(data))) => data,
-            Some(CE::SpecialFinal(None)) => ContainerData::default(),
-            Some(CE::RuntimeObject(_)) => {
+            Some(ContainerElement::SpecialFinal(Some(data))) => data,
+            Some(ContainerElement::SpecialFinal(None)) => ContainerData::default(),
+            Some(ContainerElement::RuntimeObject(_)) => {
                 return Err(ContainerError(
                     "Failed to deserialize Container, does not end with object or null",
                 ))
@@ -138,8 +137,8 @@ impl TryFrom<Vec<ContainerElement>> for Container {
         let content = elements
             .into_iter()
             .map(|item| match item {
-                CE::RuntimeObject(element) => Ok(element),
-                CE::SpecialFinal(_) => Err(ContainerError(
+                ContainerElement::RuntimeObject(element) => Ok(element),
+                ContainerElement::SpecialFinal(_) => Err(ContainerError(
                     "Failed to deserialize Container element as RuntimeObject",
                 )),
             })

--- a/src/runtime/container.rs
+++ b/src/runtime/container.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, error};
 
 use serde::Deserialize;
 
@@ -162,3 +162,5 @@ impl fmt::Display for ContainerError {
         write!(f, "{}", self.0)
     }
 }
+
+impl error::Error for ContainerError {}

--- a/src/runtime/control_command.rs
+++ b/src/runtime/control_command.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::Deserialize;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub enum ControlCommand {
     /// Begin logical evaluation mode. In evaluation mode, objects that are encounted are
     /// added to an evaluation stack, rather than simply echoed into the main text output stream.

--- a/src/runtime/debug_metadata.rs
+++ b/src/runtime/debug_metadata.rs
@@ -4,7 +4,7 @@ pub struct DebugMetadata {
     start_line_number: u32,
     end_line_number: u32,
     file_name: Option<String>,
-    source_name: Option<String>
+    source_name: Option<String>,
 }
 
 impl DebugMetadata {
@@ -13,16 +13,21 @@ impl DebugMetadata {
             start_line_number: 0,
             end_line_number: 0,
             file_name: None,
-            source_name: None
+            source_name: None,
         }
     }
 
-    pub fn from_metadata(start_line_number: u32, end_line_number: u32, file_name: String, source_name: String) -> DebugMetadata {
+    pub fn from_metadata(
+        start_line_number: u32,
+        end_line_number: u32,
+        file_name: String,
+        source_name: String,
+    ) -> DebugMetadata {
         DebugMetadata {
             start_line_number: start_line_number,
             end_line_number: end_line_number,
             file_name: Some(file_name),
-            source_name: Some(source_name)
+            source_name: Some(source_name),
         }
     }
 
@@ -37,14 +42,14 @@ impl DebugMetadata {
     pub fn file_name(&self) -> Option<&String> {
         match self.file_name {
             Some(file_name) => Some(file_name),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn source_name(&self) -> Option<&String> {
         match self.source_name {
             Some(source_name) => Some(source_name),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -53,7 +58,7 @@ impl fmt::Display for DebugMetadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.file_name {
             Some(file_name) => write!(f, "line {} of {}", self.start_line_number, file_name),
-            _ => write!(f, "line {}", self.start_line_number)
+            _ => write!(f, "line {}", self.start_line_number),
         }
     }
 }

--- a/src/runtime/debug_metadata.rs
+++ b/src/runtime/debug_metadata.rs
@@ -36,14 +36,14 @@ impl DebugMetadata {
 
     pub fn file_name(&self) -> Option<&String> {
         match self.file_name {
-            Some(ref file_name) => Some(file_name),
+            Some(file_name) => Some(file_name),
             _ => None
         }
     }
 
     pub fn source_name(&self) -> Option<&String> {
         match self.source_name {
-            Some(ref source_name) => Some(source_name),
+            Some(source_name) => Some(source_name),
             _ => None
         }
     }
@@ -52,7 +52,7 @@ impl DebugMetadata {
 impl fmt::Display for DebugMetadata {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.file_name {
-            Some(ref file_name) => write!(f, "line {} of {}", self.start_line_number, file_name),
+            Some(file_name) => write!(f, "line {} of {}", self.start_line_number, file_name),
             _ => write!(f, "line {}", self.start_line_number)
         }
     }

--- a/src/runtime/glue.rs
+++ b/src/runtime/glue.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::Deserialize;
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Deserialize, Clone)]
 pub enum Glue {
     #[serde(rename = "<>")]
     Bidirectional,

--- a/src/runtime/ink_list.rs
+++ b/src/runtime/ink_list.rs
@@ -35,14 +35,14 @@ impl InkListItem {
 
     pub fn origin_name(&self) -> Option<&String> {
         match self.origin_name {
-            Some(ref origin_name) => Some(origin_name),
+            Some(origin_name) => Some(origin_name),
             _ => None,
         }
     }
 
     pub fn item_name(&self) -> Option<&String> {
         match self.item_name {
-            Some(ref item_name) => Some(item_name),
+            Some(item_name) => Some(item_name),
             _ => None,
         }
     }
@@ -53,8 +53,8 @@ impl InkListItem {
 
     pub fn full_name(&self) -> Option<String> {
         match self.item_name {
-            Some(ref item_name) => match self.origin_name {
-                Some(ref origin_name) => Some(format!("{}.{}", origin_name, item_name)),
+            Some(item_name) => match self.origin_name {
+                Some(origin_name) => Some(format!("{}.{}", origin_name, item_name)),
                 _ => Some(format!("?.{}", item_name)),
             },
             _ => None,
@@ -110,14 +110,14 @@ impl InkList {
 
     pub fn add_origin_name(&mut self, origin_name: String) {
         match self.origin_names {
-            Some(ref mut origin_names) => origin_names.push(origin_name),
+            Some(mut origin_names) => origin_names.push(origin_name),
             _ => self.origin_names = Some(vec![origin_name]),
         }
     }
 
     pub fn add_origin_names(&mut self, input: Vec<String>) {
         match self.origin_names {
-            Some(ref mut origin_names) => {
+            Some(mut origin_names) => {
                 let mut others = input;
                 origin_names.append(&mut others)
             }
@@ -222,22 +222,22 @@ impl fmt::Display for InkList {
         let mut item_names_len: usize = 0;
 
         for (item, &value) in self.ink_list_items.iter() {
-            if let Some(ref item_name) = item.item_name {
+            if let Some(item_name) = item.item_name {
                 ordered_list.push((value, item_name));
                 item_names_len += item_name.len();
             }
         }
 
-        ordered_list.sort_by(|&(ref value, _), &(ref other_value, _)| value.cmp(other_value));
+        ordered_list.sort_by(|(value, _), (other_value, _)| value.cmp(other_value));
 
         let mut iter = ordered_list.iter();
         let mut ink_list_str = String::with_capacity(item_names_len + (ordered_list.len() - 1) * 2);
 
-        if let Some(&(_, ref item_name)) = iter.next() {
+        if let Some((_, item_name)) = iter.next() {
             ink_list_str.push_str(item_name)
         }
 
-        for &(_, ref item_name) in iter.next() {
+        for (_, item_name) in iter.next() {
             ink_list_str.push_str(", ");
             ink_list_str.push_str(item_name);
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -46,7 +46,7 @@ impl fmt::Display for RuntimeObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RuntimeObject::ControlCommand(control_command) => {
-                write!(f, "{}", control_command.to_string())
+                write!(f, "{}", control_command)
             }
             _ => write!(f, "TODO"),
         }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -96,6 +96,8 @@ where
     if s == "void" {
         Ok(())
     } else {
-        Err(D::Error::custom("Failed to deserialize string literal as void"))
+        Err(D::Error::custom(
+            "Failed to deserialize string literal as void",
+        ))
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,5 +1,7 @@
 use std::{fmt, rc::Rc};
 
+use serde::{de::Error, Deserialize, Deserializer};
+
 use crate::runtime::{
     choice_point::ChoicePoint,
     container::Container,
@@ -22,7 +24,8 @@ pub mod tag;
 pub mod value;
 pub mod variable;
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
 pub enum RuntimeObject {
     Choice(ChoicePoint),
     Container(Rc<Container>),
@@ -35,14 +38,14 @@ pub enum RuntimeObject {
     VariableAssignment(VariableAssignment),
     VariableReference(VariableReference),
     ReadCount(ReadCount),
+    #[serde(deserialize_with = "void")]
     Void,
-    Null,
 }
 
 impl fmt::Display for RuntimeObject {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &RuntimeObject::ControlCommand(ref control_command) => {
+            RuntimeObject::ControlCommand(control_command) => {
                 write!(f, "{}", control_command.to_string())
             }
             _ => write!(f, "TODO"),
@@ -53,30 +56,46 @@ impl fmt::Display for RuntimeObject {
 impl RuntimeObject {
     pub fn is_container(&self) -> bool {
         match self {
-            &RuntimeObject::Container(_) => true,
+            RuntimeObject::Container(_) => true,
             _ => false,
         }
     }
 
     pub fn as_container(&self) -> Option<&Rc<Container>> {
         match self {
-            &RuntimeObject::Container(ref container) => Some(container),
+            RuntimeObject::Container(container) => Some(container),
             _ => None,
         }
     }
 
     pub fn as_value(&self) -> Option<&Value> {
         match self {
-            &RuntimeObject::Value(ref value) => Some(value),
+            RuntimeObject::Value(value) => Some(value),
             _ => None,
         }
     }
 
     pub fn name(&self) -> Option<&str> {
-        match *self {
-            RuntimeObject::Container(ref container) => container.name(),
+        match self {
+            RuntimeObject::Container(container) => match container.name.as_ref() {
+                Some(name) => Some(name),
+                _ => None,
+            },
             // TODO
             _ => None,
         }
+    }
+}
+
+fn void<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: Deserializer<'de>,
+    D::Error: Error,
+{
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    if s == "void" {
+        Ok(())
+    } else {
+        Err(D::Error::custom("Failed to deserialize string literal as void"))
     }
 }

--- a/src/runtime/native_function_call.rs
+++ b/src/runtime/native_function_call.rs
@@ -36,4 +36,4 @@ pub enum NativeFunctionCall {
     Min,
     #[serde(rename = "MAX")]
     Max,
-  }
+}

--- a/src/runtime/native_function_call.rs
+++ b/src/runtime/native_function_call.rs
@@ -1,4 +1,39 @@
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
-pub struct NativeFunctionCall {}
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
+pub enum NativeFunctionCall {
+    #[serde(rename = "+")]
+    Plus,
+    #[serde(rename = "-")]
+    Minus,
+    #[serde(rename = "/")]
+    Divide,
+    #[serde(rename = "*")]
+    Multiply,
+    #[serde(rename = "%")]
+    Modulo,
+    #[serde(rename = "_")]
+    UnaryMinus,
+    #[serde(rename = "==")]
+    Eq,
+    #[serde(rename = ">")]
+    GT,
+    #[serde(rename = "<")]
+    LT,
+    #[serde(rename = ">=")]
+    GEq,
+    #[serde(rename = "<=")]
+    LEq,
+    #[serde(rename = "!=")]
+    NEq,
+    #[serde(rename = "!")]
+    UnaryNot,
+    #[serde(rename = "&&")]
+    And,
+    #[serde(rename = "||")]
+    Or,
+    #[serde(rename = "MIN")]
+    Min,
+    #[serde(rename = "MAX")]
+    Max,
+  }

--- a/src/runtime/tag.rs
+++ b/src/runtime/tag.rs
@@ -2,20 +2,12 @@ use std::fmt;
 
 use serde::Deserialize;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq, Eq, Clone)]
 pub struct Tag {
-    text: String,
+    #[serde(rename = "#")]
+    pub text: String,
 }
 
-impl Tag {
-    pub fn new(text: String) -> Tag {
-        Tag { text: text }
-    }
-
-    pub fn text(&self) -> &String {
-        &self.text
-    }
-}
 
 impl fmt::Display for Tag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/runtime/tag.rs
+++ b/src/runtime/tag.rs
@@ -8,7 +8,6 @@ pub struct Tag {
     pub text: String,
 }
 
-
 impl fmt::Display for Tag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "#{}", self.text)

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -67,7 +67,7 @@ impl fmt::Display for Value {
             Value::Float(value) => write!(f, "{}", value),
             Value::String(value) => write!(f, "{}", value),
             Value::DivertTarget { target_path } => {
-                write!(f, "DivertTarget({})", target_path.to_string())
+                write!(f, "DivertTarget({})", target_path)
             }
             Value::VariablePointer {
                 name,

--- a/src/runtime/variable.rs
+++ b/src/runtime/variable.rs
@@ -38,7 +38,7 @@ pub struct ReadCount {
 
 impl fmt::Display for ReadCount {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "read_count({})", self.target.to_string())
+        write!(f, "read_count({})", self.target)
     }
 }
 


### PR DESCRIPTION
Completely refactor deserialization (also remove unnecessary constructors/getters/setters, and remove "ref").
Deserialization now uses serde derives and attributes rather than visitor structs.